### PR TITLE
Update plugin name and linter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - ".:/plugin:ro"
   lint:
     image: buildkite/plugin-linter
-    command: ['--name', 'jobready/codeclimate-test-reporter-buildkite-plugin']
+    command: ['--id', 'jobready/codeclimate-test-reporter-buildkite-plugin']
     volumes:
       - ".:/plugin:ro"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: codeclimate-test-reporter
+name: Code Climate Test Reporter
 description: A Buildkite plugin to report coverage with the Code Climate test reporter
 author: https://github.com/jobready
 requirements: []


### PR DESCRIPTION
We've updated things so plugin names are now plain English. And `--name` has been renamed to `--id` for the linter, to avoid the confusion you ran into earlier.