### PR TITLE
Add support for add_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Example: `false`
 
 Controls the name outputs files formatted by the codeclimate test reporter. Required to stop artifact names clashing when processing muiltple test suites.
 
+### `add_prefix` (optional, default `<empty_string>`)
+
+Controls the prefix to add to file paths in coverage payloads, to make them match the project's directory structure.
+
+
 ### `CC_TEST_REPORTER_ID` (required)
 
 The `CC_TEST_REPORTER_ID` environment variable must be configured.

--- a/hooks/command
+++ b/hooks/command
@@ -26,6 +26,7 @@ format_file() {
     --input-type "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_INPUT_TYPE}" \
     --prefix "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_PREFIX}" \
     --output "${output_file}" \
+    --add-prefix "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_ADD_PREFIX}"
     "$1"
 }
 
@@ -73,6 +74,7 @@ debug=""
 format=${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_FORMAT:-true}
 formatted_file_prefix=${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_FILE_PREFIX:-"codeclimate"} 
 report=${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_REPORT:-true}
+add_prefix=${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_ADD_PREFIX:-""}
 
 install_reporter
 download_artifacts

--- a/hooks/command
+++ b/hooks/command
@@ -26,7 +26,7 @@ format_file() {
     --input-type "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_INPUT_TYPE}" \
     --prefix "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_PREFIX}" \
     --output "${output_file}" \
-    --add-prefix "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_ADD_PREFIX}"
+    --add-prefix "${BUILDKITE_PLUGIN_CODECLIMATE_TEST_REPORTER_ADD_PREFIX}" \
     "$1"
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,4 +22,6 @@ configuration:
       type: boolean
     file_prefix:
       type: string
+    add_prefix:
+      type: string
   required: [artifact, input_type]


### PR DESCRIPTION
Adds a parameter to allow control of `--add-prefix` in Buildkite

Not sure how to assign a reviewer, so just going to tag @s01ipsist 