### PR TITLE
Download test-reporter for current architecture

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -9,8 +9,13 @@ install_reporter() {
 
   printf -- "--- :codeclimate: Installing %s cc-test-reporter\\n" "${version}"
 
+  arch=$(uname -m)
+  if [[ "$arch" == "x86_64" ]]; then
+    arch="amd64"
+  fi
+
   curl --location --silent --output ./cc-test-reporter \
-    "https://codeclimate.com/downloads/test-reporter/test-reporter-${version}-linux-amd64" && \
+    "https://codeclimate.com/downloads/test-reporter/test-reporter-${version}-linux-${arch}" && \
   chmod +x ./cc-test-reporter
   # add current working directory to path so cc-test-reporter is accessible
   PATH=${PATH}:$(pwd)


### PR DESCRIPTION
Detect current CPU architecture with `uname` and download the corresponding `test-reporter` binary. This enables support for using the plugin on Arm64 based agents.